### PR TITLE
Test monitor manual config example

### DIFF
--- a/python/testmonitor/manual config/README.md
+++ b/python/testmonitor/manual config/README.md
@@ -1,20 +1,15 @@
-# SystemLink Test Monitor results example
+# SystemLink Test Monitor manual configuration example
 
-This is an example of uploading test results to the SystemLink Test Monitor service.
-It simulates measuring the power output from a device and tests the measured power
-to ensure it is within a specified upper and lower limit.  The power is simulated using
-the simple electrical equation `P=VI` (power=voltage*current).  In this example, a random
-amount of current loss and voltage loss are induced to simulate a non-ideal device.
+This is an example of uploading a test result to the SystemLink Test Monitor service
+using a manual configuration.  This is helpful when accessing the SystemLink server from
+a device that is not registered with the server.
 
-A top level result is created containing metadata about the overall test.
+This example accepts command-line arguments to configure the connection to the SystemLink server.
+The connection URL can be specified to connect to a specific SystemLink server.  Optionally,
+the user can specify either an API key or a username and password to connect to the server.
 
-The example sweeps across a range of input currents and voltages and takes measurements
-for each combination. It then stores each single measurement within each test step.  The test
-steps are associated with the test result, and in some cases, as child relationships
-to other test steps.  Each step is uploaded to the SystemLink server as it is generated.
-
-At the end, the step status is evaluated to set the status of the parent step and
-ultimately sets the status of the top-level test result.
+Once a connection is configured, a simple test result (with no child steps) is created on
+the server to validate that the connection information succeeds in accessing the server.
 
 ## Depenencies
 - The **NI SystemLink Python SDK** must be installed on the system using the NI Package Manager.  The package is available when installing the SystemLink Server or Client.  The NI SystemLink Python SDK is installed under `C:\Program Files\National Instruments\Shared\Skyline\Python` and contains the test monitor client which this example imports.

--- a/python/testmonitor/manual config/README.md
+++ b/python/testmonitor/manual config/README.md
@@ -1,0 +1,20 @@
+# SystemLink Test Monitor results example
+
+This is an example of uploading test results to the SystemLink Test Monitor service.
+It simulates measuring the power output from a device and tests the measured power
+to ensure it is within a specified upper and lower limit.  The power is simulated using
+the simple electrical equation `P=VI` (power=voltage*current).  In this example, a random
+amount of current loss and voltage loss are induced to simulate a non-ideal device.
+
+A top level result is created containing metadata about the overall test.
+
+The example sweeps across a range of input currents and voltages and takes measurements
+for each combination. It then stores each single measurement within each test step.  The test
+steps are associated with the test result, and in some cases, as child relationships
+to other test steps.  Each step is uploaded to the SystemLink server as it is generated.
+
+At the end, the step status is evaluated to set the status of the parent step and
+ultimately sets the status of the top-level test result.
+
+## Depenencies
+- The **NI SystemLink Python SDK** must be installed on the system using the NI Package Manager.  The package is available when installing the SystemLink Server or Client.  The NI SystemLink Python SDK is installed under `C:\Program Files\National Instruments\Shared\Skyline\Python` and contains the test monitor client which this example imports.

--- a/python/testmonitor/manual config/README.md
+++ b/python/testmonitor/manual config/README.md
@@ -12,4 +12,4 @@ Once a connection is configured, a simple test result (with no child steps) is c
 the server to validate that the connection information succeeds in accessing the server.
 
 ## Depenencies
-- The **NI SystemLink Python SDK** must be installed on the system using the NI Package Manager.  The package is available when installing the SystemLink Server or Client.  The NI SystemLink Python SDK is installed under `C:\Program Files\National Instruments\Shared\Skyline\Python` and contains the test monitor client which this example imports.
+- The **NI SystemLink Python SDK** must be installed on the system using the NI Package Manager.  The package is available when installing the SystemLink Server or Client.  The NI SystemLink Python SDK is installed under `C:\Program Files\National Instruments\Shared\Skyline\Python` and contains the `systemlink.clients.nitestmonitor` package imported by this example.

--- a/python/testmonitor/manual config/manual_config.py
+++ b/python/testmonitor/manual config/manual_config.py
@@ -1,6 +1,16 @@
 """
 SystemLink Test Monitor manual config example
 
+This is an example of uploading a test result to the SystemLink Test Monitor service
+using a manual configuration.  This is helpful when accessing the SystemLink server from
+a device that is not registered with the server.
+
+This example accepts command-line arguments to configure the connection to the SystemLink server.
+The connection URL can be specified to connect to a specific SystemLink server.  Optionally,
+the user can specify either an API key or a username and password to connect to the server.
+
+Once a connection is configured, a simple test result (with no child steps) is created on
+the server to validate that the connection information succeeds in accessing the server.
 """
 
 import sys

--- a/python/testmonitor/manual config/manual_config.py
+++ b/python/testmonitor/manual config/manual_config.py
@@ -15,7 +15,7 @@ from systemlink.clients.nitestmonitor.models.status_object import StatusObject
 
 def main():
     # Set default values
-    host = 'http://localhost/nitestmonitor'
+    host = "http://localhost/nitestmonitor"
     api_key = None
     api_key_prefix = None
     username = None
@@ -23,24 +23,21 @@ def main():
 
     # Parse command-line arguments
     for arg in sys.argv[1:]:
-        if '--host:' in arg:
-            host = arg.replace('--host:', '')
-        if '--api_key:' in arg:
-            api_key = arg.replace('--api_key:', '')
-        if '--api_key_prefix:' in arg:
-            host = arg.replace('--api_key_prefix:', '')
-        if '--username:' in arg:
-            username = arg.replace('--username:', '')
-        if '--password:' in arg:
-            password = arg.replace('--password:', '')
+        if "--host:" in arg:
+            host = arg.replace("--host:", "")
+        if "--api_key:" in arg:
+            api_key = arg.replace("--api_key:", "")
+        if "--api_key_prefix:" in arg:
+            host = arg.replace("--api_key_prefix:", "")
+        if "--username:" in arg:
+            username = arg.replace("--username:", "")
+        if "--password:" in arg:
+            password = arg.replace("--password:", "")
 
     # Create a configuration specifying the server credentials
     configuration = Configuration(
-        host=host,
-        api_key=api_key,
-        api_key_prefix=api_key_prefix,
-        username=username,
-        password=password)
+        host=host, api_key=api_key, api_key_prefix=api_key_prefix, username=username, password=password
+    )
     http_client = ApiClient(configuration)
 
     # Initialize SystemLink APIs

--- a/python/testmonitor/manual config/manual_config.py
+++ b/python/testmonitor/manual config/manual_config.py
@@ -1,0 +1,70 @@
+"""
+SystemLink Test Monitor manual config example
+
+"""
+
+import sys
+import uuid
+
+from systemlink.clients.nitestmonitor import ApiClient, ResultsApi
+from systemlink.clients.nitestmonitor.configuration import Configuration
+from systemlink.clients.nitestmonitor.models.create_test_results_request import CreateTestResultsRequest
+from systemlink.clients.nitestmonitor.models.test_result_request_object import TestResultRequestObject
+from systemlink.clients.nitestmonitor.models.status_object import StatusObject
+
+
+def main():
+    # Set default values
+    host = 'http://localhost/nitestmonitor'
+    api_key = None
+    api_key_prefix = None
+    username = None
+    password = None
+
+    # Parse command-line arguments
+    for arg in sys.argv[1:]:
+        if '--host:' in arg:
+            host = arg.replace('--host:', '')
+        if '--api_key:' in arg:
+            api_key = arg.replace('--api_key:', '')
+        if '--api_key_prefix:' in arg:
+            host = arg.replace('--api_key_prefix:', '')
+        if '--username:' in arg:
+            username = arg.replace('--username:', '')
+        if '--password:' in arg:
+            password = arg.replace('--password:', '')
+
+    # Create a configuration specifying the server credentials
+    configuration = Configuration(
+        host=host,
+        api_key=api_key,
+        api_key_prefix=api_key_prefix,
+        username=username,
+        password=password)
+    http_client = ApiClient(configuration)
+
+    # Initialize SystemLink APIs
+    results_api = ResultsApi(http_client)
+
+    test_result = TestResultRequestObject(
+        program_name="Manual Config",
+        status=StatusObject(status_type="PASSED"),
+        system_id=None,
+        host_name=None,
+        properties=None,
+        keywords=None,
+        serial_number=str(uuid.uuid4()),
+        operator="John Smith",
+        part_number="NI-ABC-123-MAN-CFG",
+        file_ids=None,
+        started_at=None,
+        total_time_in_seconds=1
+    )
+
+    create_results_request = CreateTestResultsRequest(results=[test_result])
+    response = await results_api.create_results_v2(create_results_request)
+    test_result = response.results[0]
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
This PR creates a new Test Monitor python example that shows how to use a manual configuration for the Test Monitor client API.

### Why should this Pull Request be merged?
When running on a device registered to the SystemLink server, the auto-configuration built into the API works well.  However, when running on a non-registered device, users need an example of how the connection is established and where to insert their connection information.

### What testing has been done?
Ran the example locally on my SystemLink server and verified that the manual username/password option worked successfully.