### PR TITLE
Added Analysis Automation example placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains Python-based NI SystemLink examples.
 
 ### Jupyter examples
 
-The **jupyter** folder contains Jupyter notebook examples that exercise the different SystemLink Services APIs (Tag, File, TDMReader and Test Monitor). To be able to run these examples, you need to have the "NI SystemLink Server - JupyterHub Module" installed. From the Jupyter interface in SystemLink, create an examples folder and upload all the content of the jupyter folder. For additional documentation on how to upload/download files to a Jupyter server, check https://jupyterlab.readthedocs.io/en/stable/user/files.html. Once the notebooks are uploaded, follow the instructions on each notebook.
+The **jupyter** folder contains Jupyter notebook examples that exercise the different SystemLink Services APIs (Tag, File, TDMReader and Test Monitor) and applications (Analysis Automation). To be able to run these examples, you need to have the "NI SystemLink Server - JupyterHub Module" installed. From the Jupyter interface in SystemLink, create an examples folder and upload all the content of the jupyter folder. For additional documentation on how to upload/download files to a Jupyter server, check https://jupyterlab.readthedocs.io/en/stable/user/files.html. Once the notebooks are uploaded, follow the instructions on each notebook.
 
 ### Test Monitor examples
 

--- a/jupyter/analysis-automation/BasicExample.ipynb
+++ b/jupyter/analysis-automation/BasicExample.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<table>\n",
+    "    <tr>\n",
+    "        <td><img src='../SystemLink_icon.png' /></td>\n",
+    "        <td ><h1><strong>NI SystemLink Analysis Automation Example - Placeholder</strong></h1></td>\n",
+    "    </tr>\n",
+    "</table>\n",
+    "\n",
+    "## Example placeholder\n",
+    "***\n",
+    "Final version will be added soon.\n",
+    "***"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Throughout previous and current release we added a lot of features related to the integration between jupyter hub and analayis automation. 

One of those pieces if to create a series of example notebooks related to analysis automation. The first of these example is a basic example. 
The example itself is not yet ready, but we need a placeholder at this point so that a link from our help page can be added to it (for this release). The time frame is a little tight (deadline is Thursday, 1st of April).