### PR TITLE
Use numeric value for alpha

### DIFF
--- a/jupyter/TestMonitorServiceExample.ipynb
+++ b/jupyter/TestMonitorServiceExample.ipynb
@@ -407,7 +407,7 @@
     "color = ['r' if status == 'FAILED' else 'g' for status in df_time['status']]\n",
     "\n",
     "fig = plt.figure(figsize=(10, 7))\n",
-    "plt.scatter(result_idx, df_time['total_time_in_seconds'], s=150, c=color, alpha='0.5')\n",
+    "plt.scatter(result_idx, df_time['total_time_in_seconds'], s=150, c=color, alpha=0.5)\n",
     "plt.title('Test Results - Duration', weight='bold', size='15')\n",
     "plt.xlabel('Test Runs', size='15')\n",
     "plt.ylabel('Time (seconds)', size='15')\n",
@@ -603,7 +603,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/<reponame>/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

I tried running the notebook on a SystemLink install and ran into an error "TypeError: alpha must be a float or None".

This PR fixes the error by using a float instead of a string for the alpha parameter to `matplotlib.pyplot.scatter`. [matplotlib docs](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.scatter.html#matplotlib.pyplot.scatter)

### Why should this Pull Request be merged?

The notebook should work out of the box.

### What testing has been done?

Ran the notebook with my changes and verified that no errors occur.
